### PR TITLE
lib: Include missing ccapnproto header in Makefile

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -43,6 +43,7 @@ endif
 if HAVE_CCAPNPROTO
 libzebra_la_SOURCES += qzc.capnp.c
 BUILT_SOURCES += qzc.capnp.c
+pkginclude_HEADERS += qzc.capnp.h
 endif
 
 EXTRA_DIST = \


### PR DESCRIPTION
Without this make dist doesn't include the header and the resulting
archive doesn't build.

Signed-off-by: Romanos Skiadas <rski@intracom-telecom.com>